### PR TITLE
Improve Playlist parse robustness, etc

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ export class YTMUSIC {
   authUser: number | undefined
   constructor(
     private cookie: string,
-    private args: { userID: string; authUser?: number }
+    private args?: { userID: string; authUser?: number }
   ) {
     this.cookie = cookie
     if (args?.userID) {

--- a/lib/continuations.ts
+++ b/lib/continuations.ts
@@ -2,7 +2,7 @@ import * as utils from './utils'
 
 export interface ContinuationData {
   nextContinuationData: {
-    continuation: string,
+    continuation: string
     clickTrackingParams: string
   }
 }
@@ -15,7 +15,7 @@ export interface ContinuationsContainer {
 
 function pickContinuationObject(continuationContents: any) {
   for (const key of Object.keys(continuationContents)) {
-    if (key.endsWith("Continuation")) {
+    if (key.endsWith('Continuation')) {
       return continuationContents[key]
     }
   }
@@ -23,16 +23,16 @@ function pickContinuationObject(continuationContents: any) {
 
 export function createContinuation<T, C>(
   cookie: string,
-  args: { userID?: string, authUser?: number } | undefined,
+  args: { userID?: string; authUser?: number } | undefined,
   parseContents: (renderer: any) => C,
   baseObject: T,
-  container?: ContinuationsContainer,
+  container?: ContinuationsContainer
 ): (() => Promise<T>) | undefined {
-  if (!(container?.continuations?.[0]?.nextContinuationData)) {
-    return;
+  if (!container?.continuations?.[0]?.nextContinuationData) {
+    return
   }
 
-  const continuation = container.continuations[0].nextContinuationData;
+  const continuation = container.continuations[0].nextContinuationData
 
   return async () => {
     const body: any = utils.generateBody({ userID: args?.userID })
@@ -44,13 +44,19 @@ export function createContinuation<T, C>(
       authUser: args?.authUser
     })
 
-    const data = pickContinuationObject(response.continuationContents);
-    const content = parseContents(data.contents);
+    const data = pickContinuationObject(response.continuationContents)
+    const content = parseContents(data.contents)
     const result = {
       ...baseObject,
       content,
-      continue: createContinuation(cookie, args, parseContents, baseObject, data),
-    };
-    return result;
+      continue: createContinuation(
+        cookie,
+        args,
+        parseContents,
+        baseObject,
+        data
+      )
+    }
+    return result
   }
 }

--- a/lib/continuations.ts
+++ b/lib/continuations.ts
@@ -1,0 +1,56 @@
+import * as utils from './utils'
+
+export interface ContinuationData {
+  nextContinuationData: {
+    continuation: string,
+    clickTrackingParams: string
+  }
+}
+
+export interface ContinuationsContainer {
+  continuations: {
+    [index: number]: ContinuationData
+  }
+}
+
+function pickContinuationObject(continuationContents: any) {
+  for (const key of Object.keys(continuationContents)) {
+    if (key.endsWith("Continuation")) {
+      return continuationContents[key]
+    }
+  }
+}
+
+export function createContinuation<T, C>(
+  cookie: string,
+  args: { userID?: string, authUser?: number } | undefined,
+  parseContents: (renderer: any) => C,
+  baseObject: T,
+  container?: ContinuationsContainer,
+): (() => Promise<T>) | undefined {
+  if (!(container?.continuations?.[0]?.nextContinuationData)) {
+    return;
+  }
+
+  const continuation = container.continuations[0].nextContinuationData;
+
+  return async () => {
+    const body: any = utils.generateBody({ userID: args?.userID })
+    const response = await utils.sendRequest(cookie, {
+      endpoint: 'browse',
+      body,
+      cToken: continuation.continuation,
+      itct: continuation.clickTrackingParams,
+      authUser: args?.authUser
+    })
+
+    const data = pickContinuationObject(response.continuationContents);
+    const content = parseContents(data.contents);
+    const result = {
+      ...baseObject,
+      content,
+      continue: createContinuation(cookie, args, parseContents, baseObject, data),
+    };
+    return result;
+  }
+}

--- a/lib/endpoints/HomePage.ts
+++ b/lib/endpoints/HomePage.ts
@@ -116,7 +116,9 @@ export const getHomePage = async (
     response.contents.singleColumnBrowseResultsRenderer.tabs[0].tabRenderer
   const sectionListRenderer = data.content.sectionListRenderer
 
-  const content: Carousel[] = parseCarouselContents(sectionListRenderer.contents)
+  const content: Carousel[] = parseCarouselContents(
+    sectionListRenderer.contents
+  )
 
   const home: HomePage = {
     title: data.title,
@@ -128,7 +130,7 @@ export const getHomePage = async (
     args,
     parseCarouselContents,
     home,
-    sectionListRenderer,
+    sectionListRenderer
   )
 
   return home
@@ -155,12 +157,12 @@ export const getFullHomePage = async (
   const home = await getHomePage(cookie, args)
   while (true) {
     const t = await home.continue?.()
-    if (!t || !t.content) break;
+    if (!t || !t.content) break
 
     home.content?.push(...t.content)
-    if (!t.continue) break;
+    if (!t.continue) break
 
     home.continue = t.continue
   }
-  return home;
+  return home
 }

--- a/lib/endpoints/HomePage.ts
+++ b/lib/endpoints/HomePage.ts
@@ -4,7 +4,7 @@ import CarouselItem from '../../models/CarouselItem'
 import Subtitle from '../../models/Subtitle'
 import * as utils from '../utils'
 
-const parseTwoRowItemRenderer = utils.parser<any, CarouselItem>((e: any) => {
+const parseTwoRowItemRenderer = utils.parser((e: any) => {
   const item: CarouselItem = {
     thumbnail: [],
     title: e.title.runs[0],
@@ -26,13 +26,13 @@ const parseTwoRowItemRenderer = utils.parser<any, CarouselItem>((e: any) => {
   return item
 })
 
-const parseFlexColumnRenderer = utils.parser<any, CarouselItem>((item: any) => {
+const parseFlexColumnRenderer = utils.parser((item: any) => {
   return {
     thumbnail: [],
     title: item.text.runs[0].text,
     subtitle: [],
     navigationEndpoint: item.text.runs[0].navigationEndpoint
-  }
+  } as CarouselItem
 })
 
 function parseResponsiveListItemRenderer(e: any): CarouselItem[] | undefined {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -145,14 +145,14 @@ export function filterFlatMap<T, R>(
  * In the normal case, this is a no-op; if the function throws, however,
  * we will augment the thrown Error with context bout what was being parsed.
  */
-export function parser<T, R>(f: (input: T) => R): (input: T) => R {
-  return function parserWrapper(input: T) {
+export function parser<T extends any[], R>(f: (...input: T) => R): (...input: T) => R {
+  return function parserWrapper(...input: T) {
     try {
-      return f(input)
+      return f(...input)
     } catch (e) {
       throw new Error(
         `Unexpected error: ${e.message}\nParsing: ${JSON.stringify(
-          input,
+          input[0],
           null,
           2
         )}`

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -145,7 +145,9 @@ export function filterFlatMap<T, R>(
  * In the normal case, this is a no-op; if the function throws, however,
  * we will augment the thrown Error with context bout what was being parsed.
  */
-export function parser<T extends any[], R>(f: (...input: T) => R): (...input: T) => R {
+export function parser<T extends any[], R>(
+  f: (...input: T) => R
+): (...input: T) => R {
   return function parserWrapper(...input: T) {
     try {
       return f(...input)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -155,7 +155,7 @@ export function parser<T extends any[], R>(f: (...input: T) => R): (...input: T)
           input[0],
           null,
           2
-        )}`
+        )}\n${e.stack}`
       )
     }
   }

--- a/models/HomePage.ts
+++ b/models/HomePage.ts
@@ -4,5 +4,5 @@ export default interface HomePage {
   title: string
   content?: Carousel[]
   browseId: string
-  continue?: any
+  continue?: () => Promise<HomePage>,
 }

--- a/models/HomePage.ts
+++ b/models/HomePage.ts
@@ -4,5 +4,5 @@ export default interface HomePage {
   title: string
   content?: Carousel[]
   browseId: string
-  continue?: () => Promise<HomePage>,
+  continue?: () => Promise<HomePage>
 }

--- a/models/Playlist.ts
+++ b/models/Playlist.ts
@@ -10,4 +10,5 @@ export default interface Playlist {
   playlistId: string
   content: Song[]
   setVideoId?: string
+  continue?: () => Promise<Playlist>
 }

--- a/models/Song.ts
+++ b/models/Song.ts
@@ -6,7 +6,7 @@ export interface Song {
   readonly duration?: string
   readonly thumbnail: Thumbnail[]
   readonly author: Text[]
-  readonly album: Text
+  readonly album?: Text
   readonly url: string
   readonly id: string
 }


### PR DESCRIPTION
- Improve robustness of Song parsing, handling id- and album-less songs
- Support Playlist continuations + unify continuation-fetching logic

This also introduces a somewhat breaking change where the album has to be optional. Per notes in the comments, the Song.id property *can also be optional*, but I've opted to simply omit these from results rather than introduce that breaking change. You may have different feelings here.

I've also improved the typing on the continue() property, which catches a potential bug in the getFullHomePage() method, which I've updated to reflect.
